### PR TITLE
az-digital/az_quickstart#350: Add phpcompatibility/php-compatibility to require-dev metapackage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "drupal/core-dev-pinned": "*",
         "mglaman/drupal-check": "1.1.2",
         "pheromone/phpcs-security-audit": "dev-master#1b8a61d4ac8f4f1554bcbf67865f8e1c1b213bdd",
+        "phpcompatibility/php-compatibility": "9.3.5",
         "sensiolabs/security-checker": "6.0.3"
     },
     "extra": {


### PR DESCRIPTION
Adds phpcompatibility/php-compatibility package to require-dev metapackage so PHP compatibility can be assessed.

az-digital/az_quickstart#350