### PR TITLE
Use forked version of pheromone/phpcs-security-audit with Composer 2.0 compatible patch applied.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,17 @@
             "role": "Team"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/az-digital/phpcs-security-audit"
+        }
+    ],
     "require": {
         "dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
         "drupal/core-dev-pinned": "*",
         "mglaman/drupal-check": "1.1.2",
-        "pheromone/phpcs-security-audit": "dev-master#1b8a61d4ac8f4f1554bcbf67865f8e1c1b213bdd",
+        "pheromone/phpcs-security-audit": "dev-master",
         "phpcompatibility/php-compatibility": "9.3.5",
         "sensiolabs/security-checker": "6.0.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,6 @@
             "role": "Team"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/az-digital/phpcs-security-audit"
-        }
-    ],
     "require": {
         "dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
         "drupal/core-dev-pinned": "*",


### PR DESCRIPTION
The latest commit to this repo seems to have broken all Quickstart builds due to this issue: https://github.com/FloeDesignTechnologies/phpcs-security-audit/pull/82

I've created a fork of that repo in our `az-digital` namespace with the changes from that PR applied to master here:
https://github.com/az-digital/phpcs-security-audit

This PR changes our dev metapacakge to reference our fork for now.