### PR TITLE
Closes az-digital/az_quickstart#699: Use secure version of composer/composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         }
     ],
     "require": {
+        "composer/composer": "2.0.13 as 2.0.2",
         "dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
         "drupal/core-dev-pinned": "*",
         "liuggio/fastest": "1.7.1",


### PR DESCRIPTION
Resolves az-digital/az_quickstart#699