### PR TITLE
Revert "Closes az-digital/az_quickstart#699: Use secure version of composer/composer in our require-dev metapackage. (#13)"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         }
     ],
     "require": {
-        "composer/composer": "2.0.13 as 2.0.2",
         "dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
         "drupal/core-dev-pinned": "*",
         "liuggio/fastest": "1.7.1",


### PR DESCRIPTION
This reverts commit 197f94cd9016501eddca29168ce8fb9dd8cb6d3c.  Didn't work like we hoped:

```
Your requirements could not be resolved to an installable set of packages.
  Problem 1
   - drupal/core 8.0.0-beta6 requires doctrine/common dev-master#a45d110f71c323e29f41eb0696fa230e3fa1b1b5 -> found doctrine/common[2.1.3, ..., 2.13.x-dev, 3.0.0, ..., 3.2.x-dev] but it does not match the constraint.
   - drupal/core-dev-pinned 8.0.0-alpha14 requires drupal/core 8.0.0-alpha14 -> found drupal/core[8.0.0-beta6, ..., 8.9.x-dev, 9.0.0-alpha1, ..., 9.2.x-dev] but it does not match the constraint.
   - drupal/core-dev-pinned 8.0.0-alpha15 requires drupal/core 8.0.0-alpha15 -> found drupal/core[8.0.0-beta6, ..., 8.9.x-dev, 9.0.0-alpha1, ..., 9.2.x-dev] but it does not match the constraint.
   - drupal/core-dev-pinned 8.0.0-beta1 requires drupal/core 8.0.0-beta1 -> found drupal/core[8.0.0-beta6, ..., 8.9.x-dev, 9.0.0-alpha1, ..., 9.2.x-dev] but it does not match the constraint.
   - drupal/core-dev-pinned 8.0.0-beta2 requires drupal/core 8.0.0-beta2 -> found drupal/core[8.0.0-beta6, ..., 8.9.x-dev, 9.0.0-alpha1, ..., 9.2.x-dev] but it does not match the constraint.
   - drupal/core-dev-pinned 8.0.0-beta3 requires drupal/core 8.0.0-beta3 -> found drupal/core[8.0.0-beta6, ..., 8.9.x-dev, 9.0.0-alpha1, ..., 9.2.x-dev] but it does not match the constraint.
   - drupal/core-dev-pinned 8.0.0-beta4 requires drupal/core 8.0.0-beta4 -> found drupal/core[8.0.0-beta6, ..., 8.9.x-dev, 9.0.0-alpha1, ..., 9.2.x-dev] but it does not match the constraint.
   - drupal/core-dev-pinned 8.0.0-beta5 requires drupal/core 8.0.0-beta5 -> found drupal/core[8.0.0-beta6, ..., 8.9.x-dev, 9.0.0-alpha1, ..., 9.2.x-dev] but it does not match the constraint.
   - wikimedia/composer-merge-plugin[v1.4.0, ..., v1.4.1] require composer-plugin-api ^1.0 -> found composer-plugin-api[2.0.0] but it does not match the constraint.
   - Root composer.json requires az-digital/az_quickstart dev-issue/701 -> satisfiable by az-digital/az_quickstart[dev-issue/701].
   - az-digital/az-quickstart-dev dev-main requires drupal/core-dev-pinned * -> satisfiable by drupal/core-dev-pinned[8.0.0-alpha14, ..., 8.9.x-dev, 9.0.0-alpha1, ..., 9.2.x-dev].
   - drupal/core-dev-pinned 9.1.7 requires composer/composer 2.0.2 -> satisfiable by composer/composer[2.0.2].
   - drupal/core-dev-pinned 8.0.0-beta11 requires drupal/core 8.0.0-beta11 -> satisfiable by drupal/core[8.0.0-beta11].
   - drupal/core-dev-pinned 8.0.0-beta10 requires drupal/core 8.0.0-beta10 -> satisfiable by drupal/core[8.0.0-beta10].
   - drupal/core-dev-pinned 8.0.0-beta9 requires drupal/core 8.0.0-beta9 -> satisfiable by drupal/core[8.0.0-beta9].
   - drupal/core-dev-pinned 8.0.0-beta7 requires drupal/core 8.0.0-beta7 -> satisfiable by drupal/core[8.0.0-beta7].
   - drupal/core-dev-pinned 8.0.0-beta15 requires drupal/core 8.0.0-beta15 -> satisfiable by drupal/core[8.0.0-beta15].
   - drupal/core-dev-pinned 8.0.0-beta14 requires drupal/core 8.0.0-beta14 -> satisfiable by drupal/core[8.0.0-beta14].
   - drupal/core-dev-pinned 8.0.0-beta13 requires drupal/core 8.0.0-beta13 -> satisfiable by drupal/core[8.0.0-beta13].
   - drupal/core-dev-pinned 8.0.0-beta12 requires drupal/core 8.0.0-beta12 -> satisfiable by drupal/core[8.0.0-beta12].
   - drupal/core-dev-pinned 9.1.6 requires drupal/core 9.1.6 -> satisfiable by drupal/core[9.1.6].
   - drupal/core-dev-pinned 9.1.5 requires drupal/core 9.1.5 -> satisfiable by drupal/core[9.1.5].
   - drupal/core-dev-pinned 9.1.4 requires drupal/core 9.1.4 -> satisfiable by drupal/core[9.1.4].
   - drupal/core-dev-pinned 9.1.3 requires drupal/core 9.1.3 -> satisfiable by drupal/core[9.1.3].
   - drupal/core-dev-pinned 9.1.2 requires drupal/core 9.1.2 -> satisfiable by drupal/core[9.1.2].
   - drupal/core-dev-pinned 9.1.0 requires drupal/core 9.1.0 -> satisfiable by drupal/core[9.1.0].
   - drupal/core-dev-pinned 9.1.0-rc3 requires drupal/core 9.1.0-rc3 -> satisfiable by drupal/core[9.1.0-rc3].
   - drupal/core-dev-pinned 9.1.0-rc2 requires drupal/core 9.1.0-rc2 -> satisfiable by drupal/core[9.1.0-rc2].
   - drupal/core-dev-pinned 9.1.0-rc1 requires drupal/core 9.1.0-rc1 -> satisfiable by drupal/core[9.1.0-rc1].
   - drupal/core-dev-pinned 9.1.0-beta1 requires drupal/core 9.1.0-beta1 -> satisfiable by drupal/core[9.1.0-beta1].
   - drupal/core-dev-pinned 9.1.0-alpha1 requires drupal/core 9.1.0-alpha1 -> satisfiable by drupal/core[9.1.0-alpha1].
   - drupal/core-dev-pinned 9.0.12 requires drupal/core 9.0.12 -> satisfiable by drupal/core[9.0.12].
   - drupal/core-dev-pinned 9.0.11 requires drupal/core 9.0.11 -> satisfiable by drupal/core[9.0.11].
   - drupal/core-dev-pinned 9.0.10 requires drupal/core 9.0.10 -> satisfiable by drupal/core[9.0.10].
   - drupal/core-dev-pinned 9.0.9 requires drupal/core 9.0.9 -> satisfiable by drupal/core[9.0.9].
   - drupal/core-dev-pinned 9.0.8 requires drupal/core 9.0.8 -> satisfiable by drupal/core[9.0.8].
   - drupal/core-dev-pinned 9.0.7 requires drupal/core 9.0.7 -> satisfiable by drupal/core[9.0.7].
   - drupal/core-dev-pinned 9.0.6 requires drupal/core 9.0.6 -> satisfiable by drupal/core[9.0.6].
   - drupal/core-dev-pinned 9.0.5 requires drupal/core 9.0.5 -> satisfiable by drupal/core[9.0.5].
   - drupal/core-dev-pinned 9.0.4 requires drupal/core 9.0.4 -> satisfiable by drupal/core[9.0.4].
   - drupal/core-dev-pinned 9.0.3 requires drupal/core 9.0.3 -> satisfiable by drupal/core[9.0.3].
   - drupal/core-dev-pinned 9.0.2 requires drupal/core 9.0.2 -> satisfiable by drupal/core[9.0.2].
   - drupal/core-dev-pinned 9.0.1 requires drupal/core 9.0.1 -> satisfiable by drupal/core[9.0.1].
   - drupal/core-dev-pinned 9.0.0 requires drupal/core 9.0.0 -> satisfiable by drupal/core[9.0.0].
   - drupal/core-dev-pinned 9.0.0-rc1 requires drupal/core 9.0.0-rc1 -> satisfiable by drupal/core[9.0.0-rc1].
   - drupal/core-dev-pinned 9.0.0-beta3 requires drupal/core 9.0.0-beta3 -> satisfiable by drupal/core[9.0.0-beta3].
   - drupal/core-dev-pinned 9.0.0-beta2 requires drupal/core 9.0.0-beta2 -> satisfiable by drupal/core[9.0.0-beta2].
   - drupal/core-dev-pinned 9.0.0-beta1 requires drupal/core 9.0.0-beta1 -> satisfiable by drupal/core[9.0.0-beta1].
   - drupal/core-dev-pinned 9.0.0-alpha2 requires drupal/core 9.0.0-alpha2 -> satisfiable by drupal/core[9.0.0-alpha2].
   - drupal/core-dev-pinned 9.0.0-alpha1 requires drupal/core 9.0.0-alpha1 -> satisfiable by drupal/core[9.0.0-alpha1].
   - drupal/core-dev-pinned 9.2.x-dev requires drupal/core 9.2.x-dev -> satisfiable by drupal/core[9.2.x-dev].
   - drupal/core-dev-pinned[9.1.1, ..., 9.1.x-dev] require drupal/core 9.1.x-dev -> satisfiable by drupal/core[9.1.x-dev].
   - drupal/core-dev-pinned 9.0.x-dev requires drupal/core 9.0.x-dev -> satisfiable by drupal/core[9.0.x-dev].
   - drupal/core-dev-pinned[8.9.0, ..., 8.9.x-dev] require symfony/browser-kit v3.4.41 -> satisfiable by symfony/browser-kit[v3.4.41].
   - drupal/core-dev-pinned[8.9.0-beta3, ..., 8.9.0-rc1] require symfony/browser-kit v3.4.40 -> satisfiable by symfony/browser-kit[v3.4.40].
   - drupal/core-dev-pinned[8.8.0-rc1, ..., 8.9.0-beta2] require symfony/browser-kit v3.4.35 -> satisfiable by symfony/browser-kit[v3.4.35].
   - drupal/core-dev-pinned 8.8.0-beta1 requires symfony/browser-kit v3.4.33 -> satisfiable by symfony/browser-kit[v3.4.33].
   - drupal/core-dev-pinned[8.4.0-rc2, ..., 8.7.14] require phpunit/phpunit 4.8.36 -> satisfiable by phpunit/phpunit[4.8.36].
   - drupal/core-dev-pinned[8.3.0, ..., 8.4.0-rc1] require phpunit/phpunit 4.8.35 -> satisfiable by phpunit/phpunit[4.8.35].
   - drupal/core-dev-pinned[8.2.7, ..., 8.3.0-rc2] require phpunit/phpunit 4.8.28 -> satisfiable by phpunit/phpunit[4.8.28].
   - drupal/core-dev-pinned[8.2.0, ..., 8.3.0-rc1] require phpunit/phpunit 4.8.27 -> satisfiable by phpunit/phpunit[4.8.27].
   - drupal/core-dev-pinned[8.0.0-rc1, ..., 8.2.0-rc2] require phpunit/phpunit 4.8.11 -> satisfiable by phpunit/phpunit[4.8.11].
   - drupal/core-dev-pinned 8.0.0-beta16 requires phpunit/phpunit 4.8.6 -> satisfiable by phpunit/phpunit[4.8.6].
   - You can only install one version of a package, so only one of these can be installed: composer/composer[1.9.1, ..., 1.10.15, 2.0.2, 2.0.11, 2.0.13].
   - You can only install one version of a package, so only one of these can be installed: drupal/core[8.0.0-beta6, ..., 8.9.x-dev, 9.0.0-alpha1, ..., 9.2.x-dev].
   - You can only install one version of a package, so only one of these can be installed: drupal/core[8.0.0-beta12, ..., 8.9.x-dev, 9.0.0-alpha1, ..., 9.2.x-dev].
   - You can only install one version of a package, so only one of these can be installed: drupal/core[8.4.0-rc1, ..., 8.9.x-dev, 9.0.0-alpha1, ..., 9.2.x-dev].
   - symfony/http-kernel v4.4.16 conflicts with symfony/browser-kit v3.4.41.
   - symfony/http-kernel v4.4.16 conflicts with symfony/browser-kit v3.4.40.
   - symfony/http-kernel v4.4.16 conflicts with symfony/browser-kit v3.4.35.
   - symfony/http-kernel v4.4.16 conflicts with symfony/browser-kit v3.4.33.
   - symfony/var-dumper v5.1.8 conflicts with phpunit/phpunit 4.8.36.
   - symfony/var-dumper v5.1.8 conflicts with phpunit/phpunit 4.8.35.
   - symfony/var-dumper v5.1.8 conflicts with phpunit/phpunit 4.8.28.
    - symfony/var-dumper v5.1.8 conflicts with phpunit/phpunit 4.8.27.
    - symfony/var-dumper v5.1.8 conflicts with phpunit/phpunit 4.8.11.
    - symfony/var-dumper v5.1.8 conflicts with phpunit/phpunit 4.8.6.
    - az-digital/az-quickstart-dev dev-main requires composer/composer 2.0.13 as 2.0.2 -> satisfiable by composer/composer[2.0.13].
    - drupal/core-recommended 9.1.7 requires drupal/core 9.1.7 -> satisfiable by drupal/core[9.1.7].
    - drupal/core-recommended 9.1.7 requires symfony/http-kernel v4.4.16 -> satisfiable by symfony/http-kernel[v4.4.16].
    - drupal/core-recommended 9.1.7 requires symfony/var-dumper v5.1.8 -> satisfiable by symfony/var-dumper[v5.1.8].
    - az-digital/az-quickstart-dev 1.x-dev is an alias of az-digital/az-quickstart-dev dev-main and thus requires it to be installed too.
    - drupal/core-dev-pinned 8.8.0-alpha1 requires wikimedia/composer-merge-plugin ^1.4 -> satisfiable by wikimedia/composer-merge-plugin[v1.4.0, v1.4.1].
    - az-digital/az_quickstart dev-issue/701 requires drupal/core-recommended 9.1.7 -> satisfiable by drupal/core-recommended[9.1.7].
    - drupal/core-dev-pinned 8.0.0-beta6 requires drupal/core 8.0.0-beta6 -> satisfiable by drupal/core[8.0.0-beta6].
    - Root composer.json requires az-digital/az-quickstart-dev ~1 -> satisfiable by az-digital/az-quickstart-dev[1.x-dev (alias of dev-main)].
```



