### PR TITLE
az-digital/az_quickstart#876: Adding migrate_devel and configuration inspector modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # az-quickstart-dev
 Composer require-dev dependencies for AZ Quickstart projects.
+
+**This package includes the following contrib development modules.**
+
+- [Devel](https://www.drupal.org/project/devel)
+- [Migrate Devel](https://www.drupal.org/project/migrate_devel)
+- [Configuration Inspector](https://www.drupal.org/project/config_inspector)
+

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,12 @@
     ],
     "require": {
         "dealerdirect/phpcodesniffer-composer-installer": "0.7.1",
+        "drupal/config_inspector": "2.0.1",
         "drupal/console": "1.9.8",
         "drupal/console-dotenv": "0.3.1",
         "drupal/core-dev-pinned": "*",
         "drupal/devel": "4.1.3",
+        "drupal/migrate_devel": "2.0-alpha2",
         "kint-php/kint": "4.1.1",
         "liuggio/fastest": "1.8.0",
         "mglaman/phpstan-drupal": "0.12.10",

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "drupal/console-dotenv": "0.3.1",
         "drupal/core-dev-pinned": "*",
         "drupal/devel": "4.1.5",
+        "drupal/migrate_devel": "2.0-alpha2",
         "kint-php/kint": "4.1.2",
         "liuggio/fastest": "1.8.0",
         "mglaman/phpstan-drupal": "0.12.15",

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,12 @@
     ],
     "require": {
         "dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
+        "drupal/config_inspector": "2.0.1",
         "drupal/console": "1.9.7",
         "drupal/console-dotenv": "0.3.1",
         "drupal/core-dev-pinned": "*",
-        "drupal/devel": "4.1.1",
+        "drupal/devel": "4.1.3",
+        "drupal/migrate_devel": "2.0-alpha2",
         "kint-php/kint": "3.3",
         "liuggio/fastest": "1.8.0",
         "mglaman/phpstan-drupal": "0.12.10",


### PR DESCRIPTION
When debugging migrations, the migrate devel module is invaluable, and when adding config schema, the config inspector has tests that show whether your config is valid. Also updated the readme, and updated devel to the latest version.

az-digital/az_quickstart#876