### PR TITLE
#24: Add packages.drupal.org repo to fix dependabot.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,10 @@
     ],
     "repositories": [
         {
+            "type": "composer",
+            "url": "https://packages.drupal.org/8"
+        },
+        {
             "type": "vcs",
             "url": "https://github.com/az-digital/phpcs-security-audit",
             "no-api": true


### PR DESCRIPTION
In order for dependabot to work for `drupal/` packages (like devel) we need to add the packages.drupal.org repo in this project's composer.json even though `repositories` is only ever used as a root-level composer property.