### PR TITLE
az-digital/az_quickstart#4446: Changes needed to support two dev branches in az-quickstart-dev metapackage repo.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,13 @@ version: 2
 updates:
   - package-ecosystem: "composer"
     directory: "/"
+    target-branch: "main"
     schedule:
       interval: "daily"
-    reviewers:
-      - "az-digital/developers"
+  - package-ecosystem: "composer"
+    directory: "/"
+    target-branch: "1.x"
+    schedule:
+      interval: "daily"
+    labels:
+      - "1.x only"

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.x-dev"
+            "dev-main": "3.x-dev"
         }
     }
 }


### PR DESCRIPTION
Applies changes needed to prepare for the creation of a `1.x` (legacy) dev branch in this repo as part overall plan support multiple major release specific branches in AZQS repos (az-digital/az_quickstart#4446).

- Updates dependabot config to allow PRs against both dev branches
- Change `dev-main` composer branch-alias from 1.x-dev to 3.x-dev

Changes that need to occur after this is merged:
- [ ] Create `1.x` development branch (from `main`)
- [ ] Enable branch protection rules for new `1.x` branch
- [ ] Remove `dealerdirect/phpcodesniffer-composer-installer` from `main` branch (already provided by `drupal/coder` via `drupal/core-dev`)
- [ ] Remove `phpcompatibility/php-compatibility` from `main` branch (package is unmaintained)
- [ ] Remove `phpcs-security-audit` from `repositories` and `require` in `main` branch (package is unmaintained and not that useful)