### PR TITLE
Update PR checks to account for az-digital/az_quickstart#5210 changes.

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -60,6 +60,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/az-quickstart-scaffolding
           composer config repositories.az_quickstart vcs https://github.com/az-digital/az_quickstart.git
+          composer config preferred-install.az-digital/az_quickstart source
           composer config use-github-api false
           ./quickstart_branch.sh --branch ${QUICKSTART_BRANCH_NAME}
           if [[ ${AZ_SOURCE_REF} =~ ^[0-9]\.[0-9x] ]]; then


### PR DESCRIPTION
This repo's PR check GitHub actions workflow stopped working after we merged az-digital/az_quickstart#5213 (for az-digital/az_quickstart#5210) which excluded dev/CI config files from package archives.